### PR TITLE
Fix search

### DIFF
--- a/app/js/itunes.js
+++ b/app/js/itunes.js
@@ -13,6 +13,8 @@ function getPodcasts(_SearchTerm)
     _SearchTerm = _SearchTerm.replace(/Ö/g, "O")
     _SearchTerm = _SearchTerm.replace(/Ü/g, "U")
 
+    _SearchTerm = encodeURIComponent(_SearchTerm)
+
     if (isProxySet())
     {
         makeRequest(getITunesProxyOptions(_SearchTerm), null, getResults, eRequest.http)


### PR DESCRIPTION
It is necessary to encode search term to make search work for MBCS characters (such as Korean).
