### PR TITLE
Change 'Search' to 'Find podcast'

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -40,7 +40,7 @@
                         <path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/>
                         <path d="M0 0h24v24H0z" fill="none"/>
                     </svg>
-                    <input id="search-input" type="text" name="search" placeholder="Search" onkeyup="search(this, event)">
+                    <input id="search-input" type="text" name="search" placeholder="Find podcast" onkeyup="search(this, event)">
                 </div>
                 <div id="menu">
                     <ul>

--- a/app/translations/de.json
+++ b/app/translations/de.json
@@ -11,7 +11,7 @@
 	"Go To": "Gehe zu",
 	"Settings": "Einstellungen",
 	"Player": "Wiedergabe",
-	"Search": "Suche",
+	"Search": "Finde Podcast",
 	"Favorites": "Favoriten",
 	"History": "Verlauf",
 	"Statistics": "Statistik",

--- a/app/translations/en.json
+++ b/app/translations/en.json
@@ -11,7 +11,7 @@
 	"Go To": "Go To",
 	"Settings": "Settings",
 	"Player": "Player",
-	"Search": "Search",
+	"Search": "Find podcast",
 	"Favorites": "Favorites",
 	"History": "History",
 	"Statistics": "Statistics",

--- a/app/translations/pt-BR.json
+++ b/app/translations/pt-BR.json
@@ -15,7 +15,7 @@
 	"Favorites": "Favoritos",
 	"History": "Hístorico",
 	"Statistics": "Estátisticas",
-	"Window": "Janela",
+	"Window": "Encontre podcast",
 	"Minimize": "Minimizar",
 	"Close": "Fechar",
 	"Quit": "Sair",

--- a/app/translations/pt-PT.json
+++ b/app/translations/pt-PT.json
@@ -15,7 +15,7 @@
 	"Favorites": "Favoritos",
 	"History": "Hístorico",
 	"Statistics": "Estátisticas",
-	"Window": "Janela",
+	"Window": "Encontre podcast",
 	"Minimize": "Minimizar",
 	"Close": "Fechar",
 	"Quit": "Sair",


### PR DESCRIPTION
Changes the label of search input from "Search" to "Find podcast", including translations. This is based on issue https://github.com/MrChuckomo/poddycast/issues/25.