### PR TITLE
Upgrade electron and electron packager

### DIFF
--- a/app/js/dark_mode.js
+++ b/app/js/dark_mode.js
@@ -1,4 +1,4 @@
-const {app} = require('electron').remote
+const {app, Menu} = require('electron').remote
 
 // ---------------------------------------------------------------------------------------------------------------------
 
@@ -43,9 +43,9 @@ function getDarkModeMenuItem(_ParentMenu)
 
     var MenuItem = null
 
-    for (var i = 0; i < app.getApplicationMenu().items.length; i++)
+    for (var i = 0; i < Menu.getApplicationMenu().items.length; i++)
     {
-        appMenuItem = app.getApplicationMenu().items[i]
+        appMenuItem = Menu.getApplicationMenu().items[i]
 
         for (var j = 0; j < appMenuItem.submenu.items.length; j++)
         {
@@ -62,9 +62,6 @@ function getDarkModeMenuItem(_ParentMenu)
             break
         }
     }
-
-    console.log(MenuItem);
-    
 
     return MenuItem
 }

--- a/app/js/helper/helper_global.js
+++ b/app/js/helper/helper_global.js
@@ -262,9 +262,9 @@ function parseFeedEpisodeDuration(_Duration)
 
 function setProxyMode()
 {
-    const { app } = require('electron').remote
+    const { app, Menu } = require('electron').remote
 
-    var MenuItems = app.getApplicationMenu().items
+    var MenuItems = Menu.getApplicationMenu().items
 
     for (var i = MenuItems.length - 1; i >= 0; i--)
     {
@@ -289,9 +289,9 @@ function setProxyMode()
 function isProxySet()
 {
     var ProxySettings = false;
-    const { app } = require('electron').remote
+    const { app, Menu } = require('electron').remote
 
-    var MenuItems = app.getApplicationMenu().items
+    var MenuItems = Menu.getApplicationMenu().items
 
     for (var i = MenuItems.length - 1; i >= 0; i --)
     {
@@ -403,9 +403,9 @@ function changeSettings(_FeedUrl, _ToInbox)
 
 function setMinimize()
 {
-    const { app } = require('electron').remote
+    const { app, Menu } = require('electron').remote
 
-    var MenuItems = app.getApplicationMenu().items
+    var MenuItems = Menu.getApplicationMenu().items
 
     for (var i = MenuItems.length - 1; i >= 0; i--)
     {

--- a/app/main.js
+++ b/app/main.js
@@ -34,7 +34,10 @@ function createWindow()
         minWidth: 1000,
         height: 600,
         minHeight: 600,
-        icon: trayIcon
+        icon: trayIcon,
+        webPreferences: {
+            nodeIntegration: true
+        }
     })
 
     win.loadURL(url.format
@@ -72,8 +75,8 @@ function createWindow()
     // Create RightClick context menu
     appIcon.setContextMenu(contextMenu)
 
-    // Always highlight the tray icon
-    appIcon.setHighlightMode('always')
+    // Always highlight the tray icon - deprecated
+    // appIcon.setHighlightMode('always')
 
     // The tray icon is not destroyed
     appIcon.isDestroyed(false)

--- a/app/package.json
+++ b/app/package.json
@@ -11,9 +11,9 @@
         "start": "electron ."
     },
     "dependencies": {
-        "electron": "^4.0.1"
+        "electron": "^8.2.1"
     },
     "devDependencies": {
-        "electron-packager": "^13.0.1"
+        "electron-packager": "^14.2.1"
     }
 }


### PR DESCRIPTION
- Upgrades electron dependency
- Upgrades electron-packager dependency
- Fixes issues with broken menu instance in newer electron versions
- Fixes broken node integration set to `false` by default in newer electron version
- Disables deprecated highlight mode