### PR TITLE
Fix proxy mode

### DIFF
--- a/app/js/feed.js
+++ b/app/js/feed.js
@@ -30,10 +30,7 @@ function readFeeds() {
 
         let feedUrl = '';
         for (let i = 0; i < JsonContent.length; i++) {
-            // use proxy url if proxy is set
-            feedUrl = global.isProxySet()
-                ? request.getFeedProxyOptions(JsonContent[i].feedUrl)
-                : JsonContent[i].feedUrl;
+            feedUrl = JsonContent[i].feedUrl;
 
             request
                 .requestPodcastFeed(feedUrl, false)

--- a/app/js/request.js
+++ b/app/js/request.js
@@ -7,6 +7,14 @@ const { XMLParser } = require('fast-xml-parser');
 const global = require('./helper/helper_global');
 const fs = require('fs');
 
+const axiosInstance = axios.create({
+    // fixes issue with proxy mode due to how electron apps are packaged
+    adapter: require('axios/lib/adapters/http'),
+    headers: {
+        'Accept': 'application/xml, text/xml'
+    }
+});
+
 const eRequest = {
     http: 1,
     https: 2
@@ -80,28 +88,17 @@ function makeRequest(_Options, _FallbackOptions, _Callback, _eRequest) {
 function requestPodcastFeed(feedUrl, returnRawData) {
     return new Promise((resolve, reject) => {
 
-        // TODO: finish this section when fixing proxy issues
-        // default value for axios proxy is false to disable
-        // let proxy = false
+        let requestConfig = {};
 
-        // if set, build a proxy object used within axios request
-        // if (isProxySet()) {
-        //   proxy = {
-        //     protocol: getPreference('proxy_protocol', 'http'),
-        //     host: getPreference('proxy_host', 'localhost'),
-        //     port: getPreference('proxy_port', 8080)
-        //   }
-        // }
+        // if proxy is not enabled, explicitly disable for axios
+        if (!global.isProxySet()) {
+            requestConfig = {
+                proxy: false
+            };
+        }
 
-        axios
-            .request({
-                url: feedUrl,
-                method: 'get',
-                headers: {
-                    'Accept': 'application/xml, text/xml'
-                }
-                // proxy: proxy
-            })
+        axiosInstance
+            .get(feedUrl, requestConfig)
             .then(function (response) {
                 updateFeedStatus(feedUrl, response.status);
 


### PR DESCRIPTION
I was able to find a solution to the issue with proxy requests. Axios, the library we use for requests, supports the standard proxy environment variables. However, the way that Electron packages the modules causes an issue with which http adapter Axios decides to use. Explicitly defining the adapter allows the `HTTP_PROXY` and `HTTP_PROXY` environment variables to work properly. I tested this on my end using a simple proxy app and was able to see the feed urls listed in the proxy app's UI.

Closes #29 