### PR TITLE
Do not reload app when playlist is deleted

### DIFF
--- a/app/js/drag_handler.js
+++ b/app/js/drag_handler.js
@@ -2,9 +2,9 @@
 
 const navigation = require('./helper/helper_navigation');
 
-function handleDragStart(_Event) {
-    _Event.dataTransfer.setData('text/html', this.innerHTML);
-    _Event.dataTransfer.setDragImage(this.getElementsByTagName('img')[0], -10, -10);
+function handleDragStart(dragEvent) {
+    dragEvent.dataTransfer.setData('text/html', this.innerHTML);
+    dragEvent.dataTransfer.setDragImage(this.getElementsByTagName('img')[0], -10, -10);
 
     this.classList.remove('over');
 }
@@ -20,25 +20,24 @@ function handleDragLeave() {
 }
 module.exports.handleDragLeave = handleDragLeave;
 
-function handleDragOver(_Event) {
+function handleDragOver(dragEvent) {
     // NOTE: Necessary. Allows us to drop.
 
-    if (_Event.preventDefault) {
-        _Event.preventDefault();
+    if (dragEvent.preventDefault) {
+        dragEvent.preventDefault();
     }
 
-    _Event.dataTransfer.dropEffect = 'link';
+    dragEvent.dataTransfer.dropEffect = 'link';
 
     return false;
 }
 module.exports.handleDragOver = handleDragOver;
 
-function handleDrop(_Event) {
+function handleDrop(dragEvent) {
     this.classList.remove('over');
 
     let Parser = new DOMParser();
-    console.log(_Event.dataTransfer.getData('text/html'));
-    let XmlDoc = Parser.parseFromString(_Event.dataTransfer.getData('text/html'), 'text/xml');
+    let XmlDoc = Parser.parseFromString(dragEvent.dataTransfer.getData('text/html'), 'text/xml');
     let PodcastName = XmlDoc.getElementsByClassName('podcast-entry-title')[0].innerHTML;
     let PlaylistName = this.getElementsByTagName('input')[0].value;
 

--- a/app/js/helper/helper_navigation.js
+++ b/app/js/helper/helper_navigation.js
@@ -221,11 +221,11 @@ function removeFromPlaylist(_PlaylistName, _PodcastName) {
 }
 module.exports.removeFromPlaylist = removeFromPlaylist;
 
-function deletePlaylist(_PlaylistName) {
+function deletePlaylist(playlistName, listItem) {
     let JsonContent = JSON.parse(fs.readFileSync(global.playlistFilePath, 'utf-8'));
 
     for (let i = 0; i < JsonContent.length; i++) {
-        if (_PlaylistName === JsonContent[i].playlistName) {
+        if (playlistName === JsonContent[i].playlistName) {
             JsonContent.splice(i, 1);
             break;
         }
@@ -233,9 +233,6 @@ function deletePlaylist(_PlaylistName) {
 
     fs.writeFileSync(global.playlistFilePath, JSON.stringify(JsonContent));
 
-    // TODO: clean remove
-    // TODO: do not simply reload the whole app
-
-    location.reload();
+    listItem.remove();
 }
 module.exports.deletePlaylist = deletePlaylist;

--- a/app/js/helper/helper_navigation.js
+++ b/app/js/helper/helper_navigation.js
@@ -221,8 +221,9 @@ function removeFromPlaylist(_PlaylistName, _PodcastName) {
 }
 module.exports.removeFromPlaylist = removeFromPlaylist;
 
-function deletePlaylist(playlistName, listItem) {
+function deletePlaylist(listItem) {
     let JsonContent = JSON.parse(fs.readFileSync(global.playlistFilePath, 'utf-8'));
+    const playlistName = listItem.getElementsByTagName('input')[0].value;
 
     for (let i = 0; i < JsonContent.length; i++) {
         if (playlistName === JsonContent[i].playlistName) {

--- a/app/preload.js
+++ b/app/preload.js
@@ -97,7 +97,7 @@ ipcRenderer.on('ctx-playlist-command', (e, cmd, targetId) => {
     switch (cmd) {
         case 'ctx-cmd-edit': playlist.showEditPage(target); break;
         case 'ctx-cmd-rename': playlist.enableRename(target); break;
-        case 'ctx-cmd-delete': navigation.deletePlaylist(target.getElementsByTagName('input')[0].value, target); break;
+        case 'ctx-cmd-delete': navigation.deletePlaylist(target); break;
         default: break;
     }
 });

--- a/app/preload.js
+++ b/app/preload.js
@@ -97,7 +97,7 @@ ipcRenderer.on('ctx-playlist-command', (e, cmd, targetId) => {
     switch (cmd) {
         case 'ctx-cmd-edit': playlist.showEditPage(target); break;
         case 'ctx-cmd-rename': playlist.enableRename(target); break;
-        case 'ctx-cmd-delete': navigation.deletePlaylist(target.getElementsByTagName('input')[0].value); break;
+        case 'ctx-cmd-delete': navigation.deletePlaylist(target.getElementsByTagName('input')[0].value, target); break;
         default: break;
     }
 });


### PR DESCRIPTION
Deleting a playlist no longer causes the window to be reloaded. The DOM element is passed along to allow removal of the list item without interruption.

Closes #109 