### PR TITLE
Fix new episodes feed not updating on startup

### DIFF
--- a/app/preload.js
+++ b/app/preload.js
@@ -15,12 +15,15 @@ const nav = require('./js/nav');
 
 window.addEventListener('DOMContentLoaded', () => {
     global.init();
+    audioPlayer.init();
     playlist.loadPlaylists();
-    feed.readFeeds();
-    nav.initLocalization();
     nav.showNewEpisodes();
     navigation.setItemCounts();
-    audioPlayer.init();
+    nav.initLocalization();
+    feed.readFeeds().then(() => {
+        nav.showNewEpisodes();
+        navigation.setItemCounts();
+    });
 });
 
 


### PR DESCRIPTION
I converted the `readFeeds` function into a Promise which allows us to run certain actions once we know the feeds have finished being retrieved. This fixes an issue where the new episodes list would not update properly on startup.

Resolves #120 