### PR TITLE
Allow clearing and disabling of history

### DIFF
--- a/app/css/content_right.css
+++ b/app/css/content_right.css
@@ -38,7 +38,7 @@ h1 {
 
 
 #content-right-header-actions {
-    opacity: 0.6;
+    /* opacity: 0.8; */
     align-self: center;
 }
 

--- a/app/index.html
+++ b/app/index.html
@@ -73,7 +73,7 @@
         <div id="content-right">
             <div id="content-right-header">
                 <h1 class="lead fs-3 my-auto">New Episodes</h1>
-                <div id="content-right-header-actions"></div>
+                <div class="my-auto" id="content-right-header-actions"></div>
             </div>
             <div id="content-right-body">
                 <div id="res">

--- a/app/index.html
+++ b/app/index.html
@@ -73,7 +73,7 @@
         <div id="content-right">
             <div id="content-right-header">
                 <h1 class="lead fs-3 my-auto">New Episodes</h1>
-                <div class="my-auto" id="content-right-header-actions"></div>
+                <div id="content-right-header-actions"></div>
             </div>
             <div id="content-right-body">
                 <div id="res">

--- a/app/js/helper/helper_entries.js
+++ b/app/js/helper/helper_entries.js
@@ -183,13 +183,15 @@ function deleteFromFile(_FeedUrl) {
 
             if (global.fileExistsAndIsNotEmpty(global.archivedFilePath)) {
                 ArchiveJsonContent = JSON.parse(fs.readFileSync(global.archivedFilePath, 'utf-8'));
-            } else {
+            } else if (global.getPreference('track_history', true)) {
                 fs.writeFileSync(global.archivedFilePath, JSON.stringify(ArchiveJsonContent));
             }
 
             ArchiveJsonContent.push(Feed);
 
-            fs.writeFileSync(global.archivedFilePath, JSON.stringify(ArchiveJsonContent));
+            if (global.getPreference('track_history', true)) {
+                fs.writeFileSync(global.archivedFilePath, JSON.stringify(ArchiveJsonContent));
+            }
 
             JsonContent.splice(i, 1);
             break;
@@ -199,6 +201,11 @@ function deleteFromFile(_FeedUrl) {
     fs.writeFileSync(global.newEpisodesSaveFilePath, JSON.stringify(JsonContent));
 }
 module.exports.deleteFromFile = deleteFromFile;
+
+function clearHistory() {
+    fs.writeFileSync(global.archivedFilePath, JSON.stringify([]));
+}
+module.exports.clearHistory = clearHistory;
 
 // ---------------------------------------------------------------------------------------------------------------------
 // Sort And Filter

--- a/app/js/helper/helper_global.js
+++ b/app/js/helper/helper_global.js
@@ -272,14 +272,6 @@ module.exports.parseFeedEpisodeDuration = parseFeedEpisodeDuration;
 // SETTINGS
 // ---------------------------------------------------------------------------------------------------------------------
 
-function toggleProxyMode() {
-    const proxyValue = isProxySet();
-
-    // set to true if value is undefined, otherwise use the opposite of the current value
-    setPreference('proxy_enabled', proxyValue === undefined ? true : !proxyValue);
-}
-module.exports.toggleProxyMode = toggleProxyMode;
-
 function isProxySet() {
     return getPreference('proxy_enabled', false);
 }
@@ -411,14 +403,6 @@ function setIsAddedToInbox(_FeedUrl, _ToInbox) {
     }
 }
 module.exports.setIsAddedToInbox = setIsAddedToInbox;
-
-function toggleMinimize() {
-    const minimizeValue = getPreference('minimize');
-
-    // set to true if value is undefined, otherwise use the opposite of the current value
-    setPreference('minimize', minimizeValue === undefined ? true : !minimizeValue);
-}
-module.exports.toggleMinimize = toggleMinimize;
 
 // ---------------------------------------------------------------------------------------------------------------------
 // PREFERENCES

--- a/app/js/nav.js
+++ b/app/js/nav.js
@@ -170,11 +170,20 @@ function showHistory() {
     helper.clearContent();
     navigation.setHeaderViewAction();
 
-    if (fs.existsSync(global.archivedFilePath) && fs.readFileSync(global.archivedFilePath, 'utf-8') !== '') {
+    if (global.fileExistsAndIsNotEmpty(global.archivedFilePath)) {
         let JsonContent = JSON.parse(fs.readFileSync(global.archivedFilePath, 'utf-8'));
         let List = document.getElementById('list');
 
         navigation.setGridLayout(List, false);
+
+        document.getElementById('content-right-header-actions').innerHTML = '<button id="clear-history-button" type="button"></button>';
+        let ClearButton = document.getElementById('clear-history-button');
+        ClearButton.innerText = 'Clear History';
+        ClearButton.className = 'mx-2 px-2 rounded-3 fw-light mt-4 btn btn-outline-secondary border-secondary';
+        ClearButton.onclick = () => {
+            entries.clearHistory();
+            showHistory();
+        };
 
         // NOTE: Show just the last 100 entries in History
         // TODO: The can be loaded after user interaction

--- a/app/js/nav.js
+++ b/app/js/nav.js
@@ -103,7 +103,7 @@ module.exports.showNewEpisodes = showNewEpisodes;
 
 function showFavorites() {
     helper.clearContent();
-    // navigation.setHeaderViewAction('list'); // NOTE: Toggle button for List and Grid view
+    navigation.setHeaderViewAction();
 
     if (fs.existsSync(global.saveFilePath) && fs.readFileSync(global.saveFilePath, 'utf-8') !== '') {
         let JsonContent = JSON.parse(fs.readFileSync(global.saveFilePath, 'utf-8'));

--- a/app/js/nav.js
+++ b/app/js/nav.js
@@ -176,10 +176,10 @@ function showHistory() {
 
         navigation.setGridLayout(List, false);
 
-        document.getElementById('content-right-header-actions').innerHTML = '<button id="clear-history-button" type="button"></button>';
+        document.getElementById('content-right-header-actions').innerHTML = '<button id="clear-history-button" type="button" title="Clear History"></button>';
         let ClearButton = document.getElementById('clear-history-button');
-        ClearButton.innerText = 'Clear History';
-        ClearButton.className = 'mx-2 px-2 rounded-3 fw-light mt-4 btn btn-outline-secondary border-secondary';
+        ClearButton.innerHTML = '<i class="bi bi-trash3"></i>';
+        ClearButton.className = 'm-3 px-3 rounded-3 fw-light btn btn-outline-danger';
         ClearButton.onclick = () => {
             entries.clearHistory();
             showHistory();

--- a/app/js/render.js
+++ b/app/js/render.js
@@ -4,10 +4,10 @@
  * Receive menu trigger from main proccess
  * @param {str} value Custom string, defined in the main menu items in main process
  */
-window.electronAPI.onTriggerMenu((_event, value, filePath) => {
+window.electronAPI.onTriggerMenu((_event, value, ...params) => {
     switch (value) {
-        case 'menu-opml:import': window.opmlAPI.import(filePath); break;
-        case 'menu-opml:export': window.opmlAPI.export(filePath); break;
+        case 'menu-opml:import': window.opmlAPI.import(params[0]); break;
+        case 'menu-opml:export': window.opmlAPI.export(params[0]); break;
         case 'menu-play-pause': window.audioAPI.clickPlayPause(); break;
         case 'menu-reply': window.audioAPI.clickReply(); break;
         case 'menu-forward': window.audioAPI.clickForward(); break;
@@ -22,6 +22,10 @@ window.electronAPI.onTriggerMenu((_event, value, filePath) => {
         case 'menu-color:system': window.colorAPI.system(); break;
         case 'menu-color:light': window.colorAPI.light(); break;
         case 'menu-color:dark': window.colorAPI.dark(); break;
+        // allow fall-through for these property setters
+        case 'toggle-proxy' :
+        case 'toggle-minimize' :
+        case 'toggle-history' : window.backendAPI.toggleProperty(params[0]); break;
         default: break;
     }
 });

--- a/app/js/render.js
+++ b/app/js/render.js
@@ -22,10 +22,7 @@ window.electronAPI.onTriggerMenu((_event, value, ...params) => {
         case 'menu-color:system': window.colorAPI.system(); break;
         case 'menu-color:light': window.colorAPI.light(); break;
         case 'menu-color:dark': window.colorAPI.dark(); break;
-        // allow fall-through for these property setters
-        case 'toggle-proxy' :
-        case 'toggle-minimize' :
-        case 'toggle-history' : window.backendAPI.toggleProperty(params[0]); break;
+        case 'toggle-property' : window.backendAPI.toggleProperty(params[0]); break;
         default: break;
     }
 });

--- a/app/main.js
+++ b/app/main.js
@@ -235,21 +235,21 @@ function createWindow() {
                     accelerator: 'CommandOrControl+Alt+P',
                     type: 'checkbox',
                     checked: global.getPreference('proxy_enabled', false),
-                    click: () => win.webContents.send('trigger-menu', 'toggle-proxy', 'proxy_enabled')
+                    click: () => win.webContents.send('trigger-menu', 'toggle-property', 'proxy_enabled')
                 },
                 {
                     label: translate('Minimize'),
                     accelerator: 'CommandOrControl+Alt+M',
                     type: 'checkbox',
                     checked: global.getPreference('minimize', false),
-                    click: () => win.webContents.send('trigger-menu', 'toggle-minimize', 'minimize')
+                    click: () => win.webContents.send('trigger-menu', 'toggle-property', 'minimize')
                 },
                 {
                     label: translate('Track History'),
                     accelerator: 'CommandOrControl+Alt+H',
                     type: 'checkbox',
                     checked: global.getPreference('track_history', true),
-                    click: () => win.webContents.send('trigger-menu', 'toggle-history', 'track_history')
+                    click: () => win.webContents.send('trigger-menu', 'toggle-property', 'track_history')
                 },
                 { type: 'separator' },
                 { role: 'toggledevtools' }

--- a/app/main.js
+++ b/app/main.js
@@ -235,14 +235,21 @@ function createWindow() {
                     accelerator: 'CommandOrControl+Alt+P',
                     type: 'checkbox',
                     checked: global.getPreference('proxy_enabled', false),
-                    click: () => global.toggleProxyMode()
+                    click: () => win.webContents.send('trigger-menu', 'toggle-proxy', 'proxy_enabled')
                 },
                 {
                     label: translate('Minimize'),
                     accelerator: 'CommandOrControl+Alt+M',
                     type: 'checkbox',
                     checked: global.getPreference('minimize', false),
-                    click: () => global.toggleMinimize()
+                    click: () => win.webContents.send('trigger-menu', 'toggle-minimize', 'minimize')
+                },
+                {
+                    label: translate('Track History'),
+                    accelerator: 'CommandOrControl+Alt+H',
+                    type: 'checkbox',
+                    checked: global.getPreference('track_history', true),
+                    click: () => win.webContents.send('trigger-menu', 'toggle-history', 'track_history')
                 },
                 { type: 'separator' },
                 { role: 'toggledevtools' }

--- a/app/preload.js
+++ b/app/preload.js
@@ -171,3 +171,12 @@ contextBridge.exposeInMainWorld('myAPI', {
     toggle: () => ipcRenderer.invoke('dark-mode:toggle'),
     sysLanguage : () => ipcRenderer.invoke('sys-language')
 });
+
+contextBridge.exposeInMainWorld('backendAPI', {
+    toggleProperty: (propertyName) => {
+        const value = global.getPreference(propertyName);
+
+        // set to true if value is undefined, otherwise use the opposite of the current value
+        global.setPreference(propertyName, value === undefined ? true : !value);
+    }
+});

--- a/app/translations/de.json
+++ b/app/translations/de.json
@@ -17,6 +17,7 @@
 	"Statistics": "Statistik",
 	"Window": "Fenster",
 	"Minimize": "Auf Systray minimieren (Neustart erforderlich)",
+	"Track History": "Verlauf aufzeichnen",
 	"Close": "Schließen",
 	"Quit": "Beenden",
 	"New Episodes": "Neue Episoden",

--- a/app/translations/en.json
+++ b/app/translations/en.json
@@ -17,6 +17,7 @@
 	"Statistics": "Statistics",
 	"Window": "Window",
 	"Minimize": "Minimize to systray (requires restart)",
+	"Track History": "Track History",
 	"Close": "Close",
 	"Quit": "Quit",
 	"New Episodes": "New Episodes",

--- a/app/translations/es.json
+++ b/app/translations/es.json
@@ -17,6 +17,7 @@
   "Statistics": "Estadísticas",
   "Window": "Ventana",
   "Minimize": "Minimizar a la bandeja del sistema (requiere reiniciar)",
+	"Track History": "Guardar historial",
   "Close": "Cerrar",
   "Quit": "Salga de",
   "New Episodes": "Nuevos episodios",

--- a/app/translations/fr.json
+++ b/app/translations/fr.json
@@ -17,6 +17,7 @@
 	"Statistics": "Statistiques",
 	"Window": "Fenêtre",
 	"Minimize": "Mettre dans la barre de tâches (redémarrage obligatoire)",
+	"Track History": "Enregistrer l'historique",
 	"Close": "Fermer",
 	"Quit": "Quitter",
 	"New Episodes": "Nouveaux épisodes",

--- a/app/translations/it.json
+++ b/app/translations/it.json
@@ -17,6 +17,7 @@
   "Statistics": "Statistics",
   "Window": "Window",
   "Minimize": "Minimize to systray (requires restart)",
+	"Track History": "Salvataggio della storia",
   "Close": "Close",
   "Quit": "Quit",
   "New Episodes": "New Episodes",

--- a/app/translations/ja.json
+++ b/app/translations/ja.json
@@ -17,6 +17,7 @@
   "Statistics": "統計情報",
   "Window": "窓",
   "Minimize": "シストレイまで最小化（再起動が必要",
+	"Track History": "履歴を保存する",
   "Close": "クローズ",
   "Quit": "辞める",
   "New Episodes": "新しいエピソード",

--- a/app/translations/nl.json
+++ b/app/translations/nl.json
@@ -17,6 +17,7 @@
   "Statistics": "Statistieken",
   "Window": "Venster",
   "Minimize": "Minimaliseren tot systray (vereist herstarten)",
+	"Track History": "Salvataggio della storia",
   "Close": "Sluit",
   "Quit": "Stop met",
   "New Episodes": "Nieuwe afleveringen",

--- a/app/translations/pl.json
+++ b/app/translations/pl.json
@@ -17,6 +17,7 @@
   "Statistics": "Statystyki",
   "Window": "Okno",
   "Minimize": "Minimalizuj do systraya (wymaga ponownego uruchomienia)",
+	"Track History": "Zapisać historię",
   "Close": "Close",
   "Quit": "Rezygnacja",
   "New Episodes": "Nowe odcinki",

--- a/app/translations/pt-BR.json
+++ b/app/translations/pt-BR.json
@@ -17,6 +17,7 @@
 	"Statistics": "Estátisticas",
 	"Window": "Encontre podcast",
 	"Minimize": "Minimizar para systray (requer reinicialização)",
+	"Track History": "Histórico de registros",
 	"Close": "Fechar",
 	"Quit": "Sair",
 	"New Episodes": "Novos Epísodios",

--- a/app/translations/pt-PT.json
+++ b/app/translations/pt-PT.json
@@ -17,6 +17,7 @@
 	"Statistics": "Estátisticas",
 	"Window": "Encontre podcast",
 	"Minimize": "Minimizar para systray (requer reinicialização)",
+	"Track History": "Histórico de registos",
 	"Close": "Fechar",
 	"Quit": "Sair",
 	"New Episodes": "Novos Epísodios",

--- a/app/translations/ru.json
+++ b/app/translations/ru.json
@@ -17,6 +17,7 @@
     "Statistics": "Статистика",
     "Window": "Окно",
     "Minimize": "Свернуть",
+	"Track History": "Сохранить историю",
     "Close": "Закрыть",
     "Quit": "Покинуть",
     "New Episodes": "Новые эпизоды",


### PR DESCRIPTION
Added a button on the history page that will clear current history. Added an option in the settings menu to disable history tracking. I also updated the user preference toggling to use the new window API used elsewhere. @MrChuckomo I am not good with the design portion of this, so would you be willing to edit the style for the clear history button? I only have a placeholder in currently.

Closes #53 