### PR TITLE
Track latest episode date for populating feed

### DIFF
--- a/app/js/classes/episode.js
+++ b/app/js/classes/episode.js
@@ -1,0 +1,28 @@
+'use strict';
+
+class Episode {
+    constructor(channelName, title, description, length, type, url, duration) {
+        this.channelName = channelName;
+        this.title = title;
+        this.description = description;
+        this.length = length;
+        this.type = type;
+        this.url = url;
+        this.duration = duration;
+        this.playbackPosition = 0;
+    }
+
+    toJSON() {
+        return {
+            'channelName': this.channelName,
+            'episodeTitle': this.title,
+            'episodeDescription': this.description,
+            'episodeLength': this.length,
+            'episodeType': this.type,
+            'episodeUrl': this.url,
+            'duration': this.duration,
+            'playbackPosition': this.playbackPosition
+        };
+    }
+}
+module.exports.Episode = Episode;

--- a/app/js/feed.js
+++ b/app/js/feed.js
@@ -2,6 +2,7 @@
 
 let CContentHelper = require('./helper/content');
 let CPlayer = require('./helper/player');
+const { Episode } = require('./classes/episode');
 const global = require('./helper/helper_global');
 const navigation = require('./helper/helper_navigation');
 const listItem = require('./list_item');
@@ -240,18 +241,18 @@ function displayEpisodesInList(podcastObject) {
  */
 function addToEpisodes(addEpisodeIconElement) {
     const episodeElement = addEpisodeIconElement.parentElement.parentElement;
-    const episodeObject = {
-        'channelName': episodeElement.getAttribute('channel'),
-        'episodeTitle': episodeElement.getAttribute('title'),
-        'episodeDescription': episodeElement.getAttribute('description'),
-        'episodeLength': episodeElement.getAttribute('length'),
-        'episodeType': episodeElement.getAttribute('type'),
-        'episodeUrl': episodeElement.getAttribute('url'),
-        'duration': episodeElement.getAttribute('duration'),
-        'playbackPosition': 0
-    };
 
-    saveEpisodeObject(episodeObject);
+    const episode = new Episode(
+        episodeElement.getAttribute('channel'),
+        episodeElement.getAttribute('title'),
+        episodeElement.getAttribute('description'),
+        episodeElement.getAttribute('length'),
+        episodeElement.getAttribute('type'),
+        episodeElement.getAttribute('url'),
+        episodeElement.getAttribute('duration')
+    );
+
+    saveEpisode(episode);
     addEpisodeIconElement.remove();
 }
 module.exports.addToEpisodes = addToEpisodes;
@@ -266,29 +267,35 @@ function saveLatestEpisodeJson(content) {
     if (!global.isAddedToInbox(content.link))
         return;
 
-    const episodeObject = {
-        'channelName': content.title,
-        'episodeTitle': content.items[0].title,
-        'episodeDescription': content.items[0].description,
-        'episodeLength': content.items[0].duration,
-        'episodeType': content.items[0].type,
-        'episodeUrl': content.items[0].link,
-        'duration': content.items[0].duration_formatted,
-        'playbackPosition': 0
-    };
+    const storedRecentDate = global.getFeedRecentEpisodeDate(content.link);
+    const latestDate = content.items[0].published;
 
-    // NOTE: save latest episode if not already in History
-    if (global.getValueFromFile(global.archivedFilePath, 'episodeUrl', 'episodeUrl', episodeObject['episodeUrl']) === null) {
-        saveEpisodeObject(episodeObject);
+    for (let i = 0; i < content.items.length; i++) {
+        const item = content.items[i];
+        if (storedRecentDate !== null && item.published > storedRecentDate) {
+            const episode = new Episode(
+                content.title,
+                item.title,
+                item.description,
+                item.duration,
+                item.type,
+                item.link,
+                item.duration_formatted
+            );
+            saveEpisode(episode);
+        } else {
+            break;
+        }
     }
+    global.addRecentEpisode(content.link, latestDate);
 }
 
 /**
  * Saves a podcast episode to the new episodes save file.
  * @private
- * @param {JSON} episodeObject Podcast episode data in JSON format.
+ * @param {Episode} episode Podcast episode class.
  */
-function saveEpisodeObject(episodeObject) {
+function saveEpisode(episode) {
     let JsonContent = [];
 
     if (fs.existsSync(global.newEpisodesSaveFilePath) && fs.readFileSync(global.newEpisodesSaveFilePath, 'utf-8') !== '') {
@@ -297,8 +304,8 @@ function saveEpisodeObject(episodeObject) {
         fs.writeFileSync(global.newEpisodesSaveFilePath, JSON.stringify(JsonContent));
     }
 
-    if (!global.isEpisodeAlreadySaved(episodeObject.episodeTitle)) {
-        JsonContent.push(episodeObject);
+    if (!global.isEpisodeAlreadySaved(episode.title)) {
+        JsonContent.push(episode.toJSON());
     }
 
     fs.writeFileSync(global.newEpisodesSaveFilePath, JSON.stringify(JsonContent));

--- a/app/js/helper/helper_global.js
+++ b/app/js/helper/helper_global.js
@@ -15,6 +15,7 @@ const archivedFilePath = saveDirPath + '/poddycast-archived_episodes.json';
 const playlistFilePath = saveDirPath + '/poddycast-playlists.json';
 const settingsFilePath = saveDirPath + '/poddycast-podcast_settings.json';
 const preferencesFilePath = saveDirPath + '/poddycast-app_preferences.json';
+const recentEpisodePath = saveDirPath + '/poddycast-recent_episodes.json';
 
 module.exports.saveDirPath = saveDirPath;
 module.exports.saveFilePath = saveFilePath;
@@ -23,6 +24,7 @@ module.exports.archivedFilePath = archivedFilePath;
 module.exports.playlistFilePath = playlistFilePath;
 module.exports.settingsFilePath = settingsFilePath;
 module.exports.preferencesFilePath = preferencesFilePath;
+module.exports.recentEpisodePath = recentEpisodePath;
 
 module.exports.isWindows = process.platform === 'win32';
 module.exports.isDarwin = process.platform === 'darwin';
@@ -35,6 +37,10 @@ function init() {
 
     if (!fs.existsSync(saveFilePath)) {
         fs.openSync(saveFilePath, 'w');
+    }
+
+    if (!fs.existsSync(recentEpisodePath)) {
+        fs.openSync(recentEpisodePath, 'w');
     }
 
     if (!fs.existsSync(newEpisodesSaveFilePath)) {
@@ -169,6 +175,28 @@ function isEpisodeAlreadySaved(_EpisodeTitle) {
     return FeedExists;
 }
 module.exports.isEpisodeAlreadySaved = isEpisodeAlreadySaved;
+
+function getFeedRecentEpisodeDate(feedUrl) {
+    if (fileExistsAndIsNotEmpty(recentEpisodePath)) {
+        const jsonContent = JSON.parse(fs.readFileSync(recentEpisodePath, 'utf-8'));
+        return jsonContent[feedUrl];
+    }
+
+    return null;
+}
+module.exports.getFeedRecentEpisodeDate = getFeedRecentEpisodeDate;
+
+function addRecentEpisode(feedUrl, episodeDate) {
+    let jsonContent = {};
+    if (fileExistsAndIsNotEmpty(recentEpisodePath)) {
+        jsonContent = JSON.parse(fs.readFileSync(recentEpisodePath, 'utf-8'));
+    }
+
+    jsonContent[feedUrl] = episodeDate;
+
+    fs.writeFileSync(recentEpisodePath, JSON.stringify(jsonContent));
+}
+module.exports.addRecentEpisode = addRecentEpisode;
 
 function isAlreadyInPlaylist(_ListName, _PodcastName) {
     let JsonContent = JSON.parse(fs.readFileSync(playlistFilePath, 'utf-8'));


### PR DESCRIPTION
Track the most recent episode date (in milliseconds) for a feed URL. This allows loading new episodes without needing to track full listening history. I've also added an Episode class that we can start integrating into other areas to make it easier to track/store episode info.

Resolves #128 