### PR TITLE
Make slider ignore pointer events

### DIFF
--- a/app/css/player.css
+++ b/app/css/player.css
@@ -245,6 +245,7 @@ input[id=volume]::-webkit-slider-runnable-track {
     height: 0.5em;
     background: #448AFF;
     border-radius: 5px;
+    pointer-events: none;
 }
 
 input[id=volume]:hover+#volume-fill {


### PR DESCRIPTION
Small fix. The slider used to block pointer events preventing the user from quickly adjusting the volume. Here is a comparison of old and new.
Old:
![2023-09-09 12_09_31](https://github.com/MrChuckomo/poddycast/assets/14171074/e7bd02e4-9d33-4702-a731-5540b763a627)
New:
![2023-09-09 12_10_07](https://github.com/MrChuckomo/poddycast/assets/14171074/7678fad6-fe58-40de-b618-8518ea92d6bb)
