### PR TITLE
Do not query episodes when addToInbox is false

### DIFF
--- a/app/js/feed.js
+++ b/app/js/feed.js
@@ -31,6 +31,10 @@ function readFeeds() {
         let feedUrl = '';
         let feedPromises = [];
         for (let i = 0; i < JsonContent.length; i++) {
+            // Do not query episodes if user does not want them in their inbox
+            if (!JsonContent[i].addToInbox) {
+                continue;
+            }
             feedUrl = JsonContent[i].feedUrl;
 
             feedPromises.push(


### PR DESCRIPTION
Do not query episodes if user does not have "Push to New Episodes" checked. This prevents episodes from being added to inbox but still allows seeing the podcast in the favorites list.

Resolves #143 